### PR TITLE
Refactor some socket init code.

### DIFF
--- a/server/src/server.gleam
+++ b/server/src/server.gleam
@@ -13,6 +13,7 @@ import gleam/option.{type Option, None, Some}
 import gleam/otp/actor
 import gleam/result
 import gleam/string
+import gleam/uri
 import lustre/attribute
 import lustre/element
 import lustre/element/html
@@ -243,7 +244,12 @@ pub fn main() {
             ["ws", player_id, player_name] ->
               mist.websocket(
                 request: req,
-                on_init: on_init(state_subject, player_id, player_name),
+                on_init: on_init(
+                  state_subject,
+                  player_id,
+                  uri.percent_decode(player_name)
+                    |> result.unwrap(player_name),
+                ),
                 on_close: fn(websocket) { process.send(websocket, Shutdown) },
                 handler: handle_ws_message,
               )


### PR DESCRIPTION
This PR fixes a minor bug where a player name with a special character like a space in it was percent encoded and then rendered with that encoded form.

It also refactors the `on_init` to remove the curried function in favour of gleam's function capture syntax.